### PR TITLE
Bugfix/fix MyIO.readLine() and MyIO.readString() EOF detection

### DIFF
--- a/fonte/ajuda/java/MyIO.java
+++ b/fonte/ajuda/java/MyIO.java
@@ -172,16 +172,14 @@ class MyIO {
 
    public static String readLine(){
       String s = "";
-      char tmp;
       try{
-         do{
-            tmp = (char)in.read();
-            if(tmp != '\n' && tmp != 13){
-               s += tmp;
-            }
-         }while(tmp != '\n');
+         char tmp = (char) in.read();
+         while (tmp != '\n' && tmp != (char) -1) {
+            if (tmp != '\r') s += tmp;
+            tmp = (char) in.read();
+         }
       }catch(IOException ioe){
-         System.out.println("lerPalavra: " + ioe.getMessage());
+         System.out.println("MyIO.readLine: " + ioe.getMessage());
       }
       return s;
    }

--- a/fonte/ajuda/java/MyIO.java
+++ b/fonte/ajuda/java/MyIO.java
@@ -150,16 +150,14 @@ class MyIO {
 
    public static String readString(){
       String s = "";
-      char tmp;
       try{
-         do{
-            tmp = (char)in.read();
-            if(tmp != '\n' && tmp != ' ' && tmp != 13){
-               s += tmp;
-            }
-         }while(tmp != '\n' && tmp != ' ');
+         char tmp = (char) in.read();
+         while (tmp != '\n' && tmp != ' ' && tmp != '\t' && tmp != (char) -1) {
+            if (tmp != '\r') s += tmp;
+            tmp = (char) in.read();
+         }
       }catch(IOException ioe){
-         System.out.println("lerPalavra: " + ioe.getMessage());
+         System.out.println("MyIO.readString: " + ioe.getMessage());
       }
       return s;
    }


### PR DESCRIPTION
Detectei que os métodos readString() e readLine() da MyIO ficam em looping infinito quando a entrada termina com o fim do arquivo (EOF) invés de terminar com um '\n'.

O método [in.read()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/BufferedReader.html#read()) retorna -1 caso o EOF seja detectado. Utilizo isso para evitar o looping infinito.