### PR TITLE
Fix binary tree remove method that uses a parent param

### DIFF
--- a/fonte/U7 - Árvores binárias/java/arvoreBinariaJava/ArvoreBinaria.java
+++ b/fonte/U7 - Árvores binárias/java/arvoreBinariaJava/ArvoreBinaria.java
@@ -278,17 +278,19 @@ public class ArvoreBinaria {
 	 */
 	private void remover2(int x, No i, No pai) throws Exception {
 		if (i == null) {
-         throw new Exception("Erro ao remover2!");
-      } else if (x < i.elemento) {
-         remover2(x, i.esq, i);
-      } else if (x > i.elemento) {
-         remover2(x, i.dir, i);
-      } else if (i.dir == null) {
-         pai = i.esq;
-      } else if (i.esq == null) {
-         pai = i.dir;
-      } else {
-         i.esq = antecessor(i, i.esq);
+			throw new Exception("Erro ao remover2!");
+		} else if (x < i.elemento) {
+			remover2(x, i.esq, i);
+		} else if (x > i.elemento) {
+			remover2(x, i.dir, i);
+		} else if (i.dir == null) {
+			if (x < pai.elemento) pai.esq = i.esq;
+			else pai.dir = i.esq;
+		} else if (i.esq == null) {
+			if (x < pai.elemento) pai.esq = i.dir;
+			else pai.dir = i.dir;
+		} else {
+			i.esq = antecessor(i, i.esq);
 		}
 	}
 


### PR DESCRIPTION
O problema com a abordagem atual é que quando você remove um nó filho, você precisa saber se esse nó filho foi alcançado através de pai.esq ou pai.dir para que você possa atualizar o filho certo.

Esse é o código atual (na master) com um comentário que eu adicionei:

```java
private void remover2(int x, No i, No pai) throws Exception {
	if (i == null) {
		throw new Exception("Erro ao remover2!");
	} else if (x < i.elemento) {
		remover2(x, i.esq, i);
	} else if (x > i.elemento) {
		remover2(x, i.dir, i);
	} else if (i.dir == null) {
		// Observe que fazer `pai = i.esq` não tem nenhum efeito na árvore já que `pai` é
		// uma variável local. Faria diferença atribuir por exemplo pai.esq a alguma coisa.
		pai = i.esq;
	} else if (i.esq == null) {
		pai = i.dir;
	} else {
		i.esq = antecessor(i, i.esq);
	}
}
```

A minha solução apenas checa, ao chegar no nó a ser removido, se esse nó é o filho esquerdo ou o filho direito de seu pai:

```java
	} else if (i.dir == null) {
		// `x < pai.elemento` indica que a função recursiva anterior pegou o caminho pai.esq
		if (x < pai.elemento) pai.esq = i.esq;
		else pai.dir = i.esq; // caminho contrário, pai.dir
	} else if (i.esq == null) {
		if (x < pai.elemento) pai.esq = i.dir; // mesma coisa aqui
		else pai.dir = i.dir; // mesma coisa
	} else {
```
